### PR TITLE
Add block switch support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation('org.asciidoctor:asciidoctorj:2.5.12') {
 		exclude group: 'org.jruby'
 	}
+	implementation('io.spring.asciidoctor:spring-asciidoctor-extensions-block-switch:0.6.3')
 	implementation 'org.jruby:jruby-complete:9.4.6.0'
 	implementation 'org.jsoup:jsoup:1.17.1'
 	implementation 'org.springframework.boot:spring-boot-starter-web'


### PR DESCRIPTION
This commit adds block switch support in order to be able to show tabs for Java/Kotlin or Maven/Gradle in Spring guides.
<img width="2084" height="356" alt="image" src="https://github.com/user-attachments/assets/d0be7373-04f4-4ba0-ae21-d18b8bcdc27c" />

See https://github.com/spring-io/spring-asciidoctor-extensions.